### PR TITLE
Fix env.yml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -22,11 +22,12 @@ dependencies:
     - streamlit>=0.73.1
     - einops==0.3.0
     - torch-fidelity==0.3.0
-    - transformers==4.19.2
+    - transformers
     - torchmetrics==0.6.0
     - kornia==0.6
     - gradio
+    - wandb
+    - hydra-core
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - advertorch@git+https://github.com/BorealisAI/advertorch.git
-    - -e .


### PR DESCRIPTION
remove the last line '-e .' because this repo is not a package. add wandb and hydra-core.
remove the version for transformers because current version will cause "ImportError: cannot import name 'CLIPImageProcessor' from 'transformers'"